### PR TITLE
Consolidate config checks and simplify role application.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ before_script:
 env:
   - NPM_VERSION=2
   - NPM_VERSION=3
+
+script:
+  - npm run lint
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6.10.3"
   - "6"
   - "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 node_js:
+  - "4"
   - "6.10.3"
   - "6"
   - "7"
   - "8"
+  - "node"
 before_script:
   - 'if [ "$NPM_VERSION" ]; then npm install -g npm@^$NPM_VERSION; fi'
   - 'npm --version'

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ class ServerlessPlugin {
         throw new Error('managedPolicyArns must be a single policy ARN or an array of them')
       }
 
-      this.policiesArray.forEach(policy => {
+      this.policiesArray.forEach((policy) => {
         if (!policy.match(/^arn:aws:iam::[0-9]+:policy\/.*$/)) {
           throw new Error(`"${policy}" is not a valid policy ARN.`)
         }
@@ -44,6 +44,7 @@ class ServerlessPlugin {
    */
   applyPoliciesToRole(policies, role) {
     this.log(`Updating managed policies for ${role.RoleName}...`)
+    // eslint-disable-next-line no-param-reassign
     role.ManagedPolicyArns =
       policies
         .concat(role.ManagedPolicyArns || [])

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,24 +17,22 @@ class ServerlessPlugin {
    * Verify configuration provided is a valid one.
    */
   verifyConfig() {
-    const policies = this.serverless.service.provider.managedPolicyArns
+    const policies = this.serverless.service.provider.managedPolicyArns || []
 
-    if (policies) {
-      // Must be a string for a single policy or an array for multiple.
-      if (typeof policies === 'string') {
-        this.policiesArray = [policies]
-      } else if (policies instanceof Array) {
-        this.policiesArray = policies
-      } else {
-        throw new Error('managedPolicyArns must be a single policy ARN or an array of them')
-      }
-
-      this.policiesArray.forEach((policy) => {
-        if (!policy.match(/^arn:aws:iam::[0-9]+:policy\/.*$/)) {
-          throw new Error(`"${policy}" is not a valid policy ARN.`)
-        }
-      })
+    // Must be a string for a single policy or an array for multiple.
+    if (typeof policies === 'string') {
+      this.policiesArray = [policies]
+    } else if (policies instanceof Array) {
+      this.policiesArray = policies
+    } else {
+      throw new Error('managedPolicyArns must be a single policy ARN or an array of them')
     }
+
+    this.policiesArray.forEach((policy) => {
+      if (!policy.match(/^arn:aws:iam::[0-9]+:policy\/.*$/)) {
+        throw new Error(`"${policy}" is not a valid policy ARN.`)
+      }
+    })
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,25 +7,33 @@ class ServerlessPlugin {
    */
   constructor(serverless) {
     this.serverless = serverless
+    this.log = serverless.cli.log
     this.hooks = {
       'before:deploy:deploy': this.attachManagedPolicy.bind(this),
     }
   }
 
   /**
-   * Get the policy or policies to be applied as an array.
-   * @param   {string|string[]} policies Single policy ARN or array of them.
-   * @returns {string[]}                 Array of policy ARNs.
+   * Verify configuration provided is a valid one.
    */
-  // eslint-disable-next-line class-methods-use-this
-  policiesArray(policies) {
-    // Must be a string for a single policy or an array for multiple.
-    if (typeof policies === 'string') {
-      return [policies]
-    } else if (policies instanceof Array) {
-      return policies
-    } else {
-      throw new Error('managedPolicyArns must be an array')
+  verifyConfig() {
+    const policies = this.serverless.service.provider.managedPolicyArns
+
+    if (policies) {
+      // Must be a string for a single policy or an array for multiple.
+      if (typeof policies === 'string') {
+        this.policiesArray = [policies]
+      } else if (policies instanceof Array) {
+        this.policiesArray = policies
+      } else {
+        throw new Error('managedPolicyArns must be a single policy ARN or an array of them')
+      }
+
+      this.policiesArray.forEach(policy => {
+        if (!policy.match(/^arn:aws:iam::[0-9]+:policy\/.*$/)) {
+          throw new Error(`"${policy}" is not a valid policy ARN.`)
+        }
+      })
     }
   }
 
@@ -35,31 +43,11 @@ class ServerlessPlugin {
    * @param {Object}          role      CFT Role Resource to add the policies.
    */
   applyPoliciesToRole(policies, role) {
-    const { cli } = this.serverless
-
-    policies.forEach((policyArn) => {
-      // Valid Policy ARN?
-      if (!policyArn.match(/^arn:aws:iam::[0-9]+:policy\/.*$/)) {
-        throw new Error(`"${policyArn}" is not a valid policy ARN.`)
-      }
-
-      // Don't bother applying policy if already applied.
-      if (role.ManagedPolicyArns && role.ManagedPolicyArns.indexOf(policyArn) !== -1) {
-        cli.log(`${role.RoleName} role already has policy ${policyArn} applied, skipping.`)
-        return
-      }
-
-      // Either add to list of existing policies or start a list with this one.
-      if (role.ManagedPolicyArns) {
-        cli.log(`Adding ${policyArn} to existing ManagedPolicyArns policies for ${role.RoleName}.`)
-        // eslint-disable-next-line no-param-reassign
-        role.ManagedPolicyArns = role.ManagedPolicyArns.concat(policyArn)
-      } else {
-        cli.log(`Setting ${policyArn} as ManagedPolicyArn for ${role.RoleName}.`)
-        // eslint-disable-next-line no-param-reassign
-        role.ManagedPolicyArns = [policyArn]
-      }
-    })
+    this.log(`Updating managed policies for ${role.RoleName}...`)
+    role.ManagedPolicyArns =
+      policies
+        .concat(role.ManagedPolicyArns || [])
+        .filter((elem, index, self) => index === self.indexOf(elem))
   }
 
   /**
@@ -68,24 +56,22 @@ class ServerlessPlugin {
    * to each of the roles in the service.
    */
   attachManagedPolicy() {
-    // Bail if not policies are to be applied.
+    // Bail if not policies are to be applied or no resources defined.
     if (!(this.serverless.service.provider.managedPolicyArns)) return
     if (!(this.serverless.service.provider.compiledCloudFormationTemplate.Resources)) return
 
-    const { cli } = this.serverless
-    const policies = this.serverless.service.provider.managedPolicyArns
+    this.verifyConfig()
     const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources
 
-    cli.log('Adding managed policies...')
-    cli.log('Searching for roles...')
+    this.log('Begin Attach Managed Policies plugin...')
 
     // Filter for any IAM Roles defined in CFT and apply our Managed Policies.
     Object.keys(resources)
       .filter(resourceName => resources[resourceName].Type === 'AWS::IAM::Role')
       .forEach(roleResource =>
-        this.applyPoliciesToRole(this.policiesArray(policies), resources[roleResource].Properties))
+        this.applyPoliciesToRole(this.policiesArray, resources[roleResource].Properties))
 
-    cli.log('Managed policy done.')
+    this.log('Attach Managed Policies plugin done.')
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-attach-managed-policy",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -73,13 +73,15 @@ const testPolicyArn1 = 'arn:aws:iam::789763425617:policy/someteam/AnotherManaged
 
 describe('Attach Managed Policy Serverless Plugin', () => {
   it('can be instantiated', () => {
-    const thePlugin = new Plugin({})
+    const slsStub = serverlessStub(null, null)
+    const thePlugin = new Plugin(slsStub)
 
     expect(thePlugin).to.be.an.instanceOf(Plugin)
   })
 
   it('hooks the Serverless "before:deploy:deploy" event', () => {
-    const thePlugin = new Plugin({})
+    const slsStub = serverlessStub(null, null)
+    const thePlugin = new Plugin(slsStub)
 
     expect(thePlugin.hooks).to.have.all.keys(['before:deploy:deploy'])
   })
@@ -117,9 +119,8 @@ describe('Attach Managed Policy Serverless Plugin', () => {
     thePlugin.attachManagedPolicy()
 
     checkLog(slsStub.cli, [
-      'Adding managed policies...',
-      'Searching for roles...',
-      'Managed policy done.',
+      'Begin Attach Managed Policies plugin...',
+      'Attach Managed Policies plugin done.',
     ])
   })
 
@@ -144,11 +145,11 @@ describe('Attach Managed Policy Serverless Plugin', () => {
     expect(resources.MyRole.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn0)
 
     checkLog(slsStub.cli, [
-      'Adding managed policies...',
-      'Searching for roles...',
-      `${testResources0.MyRole.Properties.RoleName} role already has policy ${testPolicyArn0} applied, skipping.`,
-      'Managed policy done.',
+      'Begin Attach Managed Policies plugin...',
+      'Updating managed policies for MyRole...',
+      'Attach Managed Policies plugin done.',
     ])
+
   })
 
   it('can add a policy where none exist', () => {
@@ -161,10 +162,9 @@ describe('Attach Managed Policy Serverless Plugin', () => {
     expect(resources.MyRole.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn0)
 
     checkLog(slsStub.cli, [
-      'Adding managed policies...',
-      'Searching for roles...',
-      `Setting ${testPolicyArn0} as ManagedPolicyArn for ${testResources0.MyRole.Properties.RoleName}.`,
-      'Managed policy done.',
+      'Begin Attach Managed Policies plugin...',
+      'Updating managed policies for MyRole...',
+      'Attach Managed Policies plugin done.',
     ])
   })
 
@@ -178,10 +178,9 @@ describe('Attach Managed Policy Serverless Plugin', () => {
     expect(resources.MyRole.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn0)
 
     checkLog(slsStub.cli, [
-      'Adding managed policies...',
-      'Searching for roles...',
-      `Setting ${testPolicyArn0} as ManagedPolicyArn for ${testResources0.MyRole.Properties.RoleName}.`,
-      'Managed policy done.',
+      'Begin Attach Managed Policies plugin...',
+      'Updating managed policies for MyRole...',
+      'Attach Managed Policies plugin done.',
     ])
   })
 
@@ -193,14 +192,13 @@ describe('Attach Managed Policy Serverless Plugin', () => {
     thePlugin.attachManagedPolicy()
 
     expect(resources.MyRole.Properties.ManagedPolicyArns.length).to.equal(2)
-    expect(resources.MyRole.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn0)
-    expect(resources.MyRole.Properties.ManagedPolicyArns[1]).to.equal(testPolicyArn1)
+    expect(resources.MyRole.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn1)
+    expect(resources.MyRole.Properties.ManagedPolicyArns[1]).to.equal(testPolicyArn0)
 
     checkLog(slsStub.cli, [
-      'Adding managed policies...',
-      'Searching for roles...',
-      `Adding ${testPolicyArn1} to existing ManagedPolicyArns policies for ${testResources0.MyRole.Properties.RoleName}.`,
-      'Managed policy done.',
+      'Begin Attach Managed Policies plugin...',
+      'Updating managed policies for MyRole...',
+      'Attach Managed Policies plugin done.',
     ])
   })
 
@@ -217,23 +215,19 @@ describe('Attach Managed Policy Serverless Plugin', () => {
     expect(resources.MyRole0.Properties.ManagedPolicyArns[1]).to.equal(testPolicyArn1)
 
     expect(resources.MyRole1.Properties.ManagedPolicyArns.length).to.equal(2)
-    expect(resources.MyRole1.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn1)
-    expect(resources.MyRole1.Properties.ManagedPolicyArns[1]).to.equal(testPolicyArn0)
+    expect(resources.MyRole1.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn0)
+    expect(resources.MyRole1.Properties.ManagedPolicyArns[1]).to.equal(testPolicyArn1)
 
     expect(resources.MyRole2.Properties.ManagedPolicyArns.length).to.equal(2)
     expect(resources.MyRole2.Properties.ManagedPolicyArns[0]).to.equal(testPolicyArn0)
     expect(resources.MyRole2.Properties.ManagedPolicyArns[1]).to.equal(testPolicyArn1)
 
     checkLog(slsStub.cli, [
-      'Adding managed policies...',
-      'Searching for roles...',
-      `${testResources1.MyRole0.Properties.RoleName} role already has policy ${testPolicyArn0} applied, skipping.`,
-      `Adding ${testPolicyArn1} to existing ManagedPolicyArns policies for ${testResources1.MyRole0.Properties.RoleName}.`,
-      `Adding ${testPolicyArn0} to existing ManagedPolicyArns policies for ${testResources1.MyRole1.Properties.RoleName}.`,
-      `${testResources1.MyRole1.Properties.RoleName} role already has policy ${testPolicyArn1} applied, skipping.`,
-      `Setting ${testPolicyArn0} as ManagedPolicyArn for ${testResources1.MyRole2.Properties.RoleName}.`,
-      `Adding ${testPolicyArn1} to existing ManagedPolicyArns policies for ${testResources1.MyRole2.Properties.RoleName}.`,
-      'Managed policy done.',
+      'Begin Attach Managed Policies plugin...',
+      'Updating managed policies for MyRole0...',
+      'Updating managed policies for MyRole1...',
+      'Updating managed policies for MyRole2...',
+      'Attach Managed Policies plugin done.',
     ])
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -149,7 +149,6 @@ describe('Attach Managed Policy Serverless Plugin', () => {
       'Updating managed policies for MyRole...',
       'Attach Managed Policies plugin done.',
     ])
-
   })
 
   it('can add a policy where none exist', () => {


### PR DESCRIPTION
Thanks to @erikerikson great feedback on the initial implementation.

These changes push the configuration validation code to the start of the plugin invocation. Also reduces the code to apply the policies to the roles.