### PR TITLE
Enabled AWS managed policy.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ class ServerlessPlugin {
     }
 
     this.policiesArray.forEach((policy) => {
-      if (!policy.match(/^arn:aws:iam::[0-9]+:policy\/.*$/)) {
+      if (!policy.match(/^arn:aws:iam::([0-9]+|aws):policy\/.*$/)) {
         throw new Error(`"${policy}" is not a valid policy ARN.`)
       }
     })


### PR DESCRIPTION
## What did you implement:

Enable AWS managed policy.

https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#aws-managed-policies

## How did you implement it:

AWS managed policy's ARN format is `arn:aws:iam::aws:policy/{{ROLE_NAME}}`.
But, This format is `ServerlessPlugin#verifyConfig()` is not acceptable.
So, I touch up.